### PR TITLE
Add more usearch experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ python/data/raw/*.hdf5
 /poetry.toml
 *.png
 *.pdf
+*.txt
+
+*.usearch

--- a/embedded-c++/CMakeLists.txt
+++ b/embedded-c++/CMakeLists.txt
@@ -24,7 +24,6 @@ set(UTILS_SOURCES
     usearch/helpers/database_setup.cpp
     usearch/helpers/file_operations.cpp
     usearch/helpers/query_runner.cpp
-    # Add any missing implementation files here
 )
 
 # Shared helper classes - built as STATIC library
@@ -43,6 +42,3 @@ target_link_libraries(usearch_full_coverage usearch_utils duckdb)
 target_link_libraries(usearch_new_data usearch_utils duckdb)
 target_link_libraries(usearch_unreachable_points usearch_utils duckdb)
 target_link_libraries(usearch_create_indexes usearch_utils duckdb)
-
-# Show verbose output during linking if there are issues
-set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/embedded-c++/CMakeLists.txt
+++ b/embedded-c++/CMakeLists.txt
@@ -4,14 +4,14 @@ project(example-c++)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_compile_options(-O3)
+add_compile_options(-Ofast)
 # add_compile_options(-g) # for debug -- SLOW
 
 include_directories(
-    ../duckdb/src/include 
-    include 
+    ../duckdb/src/include
+    include
     ../src/include
-    ${CMAKE_CURRENT_SOURCE_DIR}  
+    ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/usearch/helpers
 )
 
@@ -35,10 +35,14 @@ target_link_libraries(usearch_utils duckdb)
 add_executable(usearch_random usearch/random.cpp)
 add_executable(usearch_full_coverage usearch/full_coverage.cpp)
 add_executable(usearch_new_data usearch/new_data.cpp)
+add_executable(usearch_unreachable_points usearch/unreachable_points.cpp)
+add_executable(usearch_create_indexes usearch/create_index.cpp)
 
 target_link_libraries(usearch_random usearch_utils duckdb)
 target_link_libraries(usearch_full_coverage usearch_utils duckdb)
 target_link_libraries(usearch_new_data usearch_utils duckdb)
+target_link_libraries(usearch_unreachable_points usearch_utils duckdb)
+target_link_libraries(usearch_create_indexes usearch_utils duckdb)
 
 # Show verbose output during linking if there are issues
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/embedded-c++/CMakeLists.txt
+++ b/embedded-c++/CMakeLists.txt
@@ -4,7 +4,7 @@ project(example-c++)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_compile_options(-Ofast)
+add_compile_options(-O3 -ffast-math)
 # add_compile_options(-g) # for debug -- SLOW
 
 include_directories(

--- a/embedded-c++/Makefile
+++ b/embedded-c++/Makefile
@@ -1,21 +1,4 @@
-.PHONY: clean prepare-build duckdb-vss duckdb-vss-debug bm_performance recall recall-debug usearch_random usearch_full_coverage usearch_new_data usearch_create_indexes all-usearch build-usearch
-
-# Build everything once, then run all programs
-all-usearch: build-usearch
-	build/usearch_unreachable_points
-	build/usearch_full_coverage
-	build/usearch_random
-	build/usearch_new_data
-
-# Build all executables only once
-build-usearch: clean prepare-build
-	cd build && cmake .. && make
-
-clean:
-	rm -rf build
-
-prepare-build:
-	mkdir -p build
+.PHONY: clean prepare-build duckdb-vss duckdb-vss-debug build run-create-indexes run-random run-full-coverage run-new-data run-unreachable-points run-all-experiments
 
 duckdb-vss:
 	cd ../ && make
@@ -23,17 +6,31 @@ duckdb-vss:
 duckdb-vss-debug:
 	cd ../ && make debug
 
-usearch_random: build-usearch
-	build/usearch_random
+clean:
+	rm -rf build
 
-usearch_unreachable_points: build-usearch
-	build/usearch_unreachable_points
+prepare-build:
+	mkdir -p build
 
-usearch_full_coverage: build-usearch
-	build/usearch_full_coverage
+build: clean prepare-build
+	cd build && cmake .. && make
 
-usearch_new_data: build-usearch
-	build/usearch_new_data
+run-create-indexes: build
+	./build/usearch_create_indexes
+	
+run-random: build
+	./build/usearch_random
+run-full-coverage: build
+	./build/usearch_full_coverage
+run-new-data: build
+	./build/usearch_new_data
+run-unreachable-points: build
+	./build/usearch_unreachable_points
 
-usearch_create_indexes: build-usearch
-	build/usearch_create_indexes
+run-all-experiments: build
+	@echo "Running all usearch experiments..."
+	./build/usearch_random
+	./build/usearch_full_coverage
+	./build/usearch_new_data
+	./build/usearch_unreachable_points
+	@echo "All usearch experiments completed."

--- a/embedded-c++/Makefile
+++ b/embedded-c++/Makefile
@@ -1,6 +1,15 @@
-.PHONY: clean prepare-build duckdb-vss duckdb-vss-debug bm_performance recall recall-debug usearch_random usearch_full_coverage usearch_new_data
+.PHONY: clean prepare-build duckdb-vss duckdb-vss-debug bm_performance recall recall-debug usearch_random usearch_full_coverage usearch_new_data usearch_create_indexes all-usearch build-usearch
 
-all-usearch: usearch_full_coverage usearch_random usearch_new_data
+# Build everything once, then run all programs
+all-usearch: build-usearch
+	build/usearch_unreachable_points
+	build/usearch_full_coverage
+	build/usearch_random
+	build/usearch_new_data
+
+# Build all executables only once
+build-usearch: clean prepare-build
+	cd build && cmake .. && make
 
 clean:
 	rm -rf build
@@ -14,14 +23,17 @@ duckdb-vss:
 duckdb-vss-debug:
 	cd ../ && make debug
 
-usearch_random: clean prepare-build
-	cd build && cmake .. && make
+usearch_random: build-usearch
 	build/usearch_random
 
-usearch_full_coverage: clean prepare-build
-	cd build && cmake .. && make
+usearch_unreachable_points: build-usearch
+	build/usearch_unreachable_points
+
+usearch_full_coverage: build-usearch
 	build/usearch_full_coverage
 
-usearch_new_data: clean prepare-build
-	cd build && cmake .. && make
+usearch_new_data: build-usearch
 	build/usearch_new_data
+
+usearch_create_indexes: build-usearch
+	build/usearch_create_indexes

--- a/embedded-c++/usearch/create_index.cpp
+++ b/embedded-c++/usearch/create_index.cpp
@@ -1,0 +1,176 @@
+#include <usearch/index.hpp>
+#include <usearch/index_dense.hpp>
+#include "duckdb.hpp"
+#include "usearch/helpers/index_operations.h"
+#include "usearch/helpers/database_setup.h"
+#include "usearch/helpers/query_runner.h"
+#include "usearch/helpers/file_operations.h"
+
+using namespace duckdb;
+using namespace unum::usearch;
+
+// ==================== USearch Index Creator ====================
+class USearchIndexCreator {
+private:
+    DuckDB db;
+    Connection con;
+    std::vector<DatasetConfig> datasets;
+    int max_iterations;
+    int threads;
+
+public:
+USearchIndexCreator(int threads = 64) : db(nullptr), con(db) {
+        con.Query("SET THREADS TO " + std::to_string(threads) + ";");
+        datasets = DatabaseSetup::getDatasetConfigs();
+    }
+
+    void createIndexes(int datasetIdx = 0) {
+        try {
+            // Limit to valid dataset indices
+            if (datasetIdx < 0 || datasetIdx >= (int)datasets.size()) {
+                std::cerr << "Invalid dataset index: " << datasetIdx << std::endl;
+                return;
+            }
+
+            const auto& dataset = datasets[datasetIdx];
+
+            std::cout << "Creating first half of index for dataset: " << dataset.name << "..." << std::endl;
+
+            // Setup database tables
+            DatabaseSetup::setupFullDataset(con, dataset);
+
+            // Create the usearch index
+            std::size_t vector_size = dataset.dimensions;
+            auto scalar_kind = scalar_kind_t::f32_k;
+            auto metric_kind = metric_kind_t::l2sq_k;
+
+            metric_punned_t metric(vector_size, metric_kind, scalar_kind);
+            index_dense_config_t config = {};
+
+            // Set M and efConstruction based on dataset
+            config.expansion_add = dataset.ef_construction;
+            config.connectivity = dataset.m;
+		    config.connectivity_base = config.connectivity * 2;
+
+            auto index = index_dense_gt<row_t>::make(metric, config);
+
+            auto dataset_cardinality = con.Query("SELECT COUNT(*) FROM " + dataset.name + "_train;")->GetValue<int64_t>(0, 0);
+
+            // Partition dataset into 20
+            auto partitions = QueryRunner::partitionDataset(con, dataset.name, 20);
+
+            auto half_count = dataset_cardinality / 2;
+
+            std::size_t executor_threads = std::min(std::thread::hardware_concurrency(),
+                                                static_cast<unsigned int>(half_count));
+            executor_default_t executor(executor_threads);
+
+            index.reserve(index_limits_t {NextPowerOfTwo(half_count), executor.size()});
+
+            std::vector<int> ids;
+            std::vector<std::vector<float>> vectors;
+            ids.reserve(half_count);
+            vectors.reserve(half_count);
+
+            // Populate index with first half
+            for (idx_t i = 0; i < 10; i++) {
+                auto& partition = partitions[i];
+                for (idx_t j = 0; j < partition->RowCount(); j++) {
+                    ids.push_back(partition->GetValue<int>(0, j));
+                    vectors.push_back(ExtractFloatVector(partition->GetValue(1, j)));
+                }
+            }
+
+            executor.fixed(half_count, [&](std::size_t thread, std::size_t task) {
+                try {
+                    int id = ids[task];
+                    auto& vec = vectors[task];
+
+                    index.add(id, vec.data(), thread);
+                }
+                catch (const std::exception& e) {
+                    std::cerr << "Error adding vector " << task << ": " << e.what() << std::endl;
+                }
+            });
+
+            // Save the index to disk
+            std::string path_half = "usearch/indexes/" + dataset.name + "_index_half.usearch";
+            std::filesystem::create_directories("usearch/indexes/");
+            index.save(path_half.c_str());
+            std::cout << "Index saved to: " << path_half << std::endl;
+
+
+            // Populate index with second half
+
+            std::cout << "Creating second half of index for dataset: " << dataset.name << "..." << std::endl;
+
+            index.reserve(index_limits_t {NextPowerOfTwo(dataset_cardinality), executor.size()});
+
+            // Clear vectors and ids for second half
+            ids.clear();
+            vectors.clear();
+            ids.reserve(half_count);
+            vectors.reserve(half_count);
+
+            // Add rest of vectors to index
+            for (idx_t i = 10; i < 20; i++) {
+                auto& partition = partitions[i];
+                for (idx_t j = 0; j < partition->RowCount(); j++) {
+                    ids.push_back(partition->GetValue<int>(0, j));
+                    vectors.push_back(ExtractFloatVector(partition->GetValue(1, j)));
+                }
+            }
+
+            executor.fixed(half_count, [&](std::size_t thread, std::size_t task) {
+                try {
+                    int id = ids[task];
+                    auto& vec = vectors[task];
+
+                    index.add(id, vec.data(), thread);
+                }
+                catch (const std::exception& e) {
+                    std::cerr << "Error adding vector " << task << ": " << e.what() << std::endl;
+                }
+            });
+
+            // Save the index to disk
+            std::string path = "usearch/indexes/" + dataset.name + "_index.usearch";
+            std::filesystem::create_directories("usearch/indexes/");
+            index.save(path.c_str());
+            std::cout << "Index saved to: " << path << std::endl;
+
+        } catch (std::exception& e) {
+            std::cerr << "Error creating index: " << e.what() << std::endl;
+        }
+    }
+};
+
+// ==================== Main Function ====================
+int main() {
+
+    /**
+     * Create and save USearch index for each dataset. The index will be reused
+     * for all experiments.
+     */
+
+    try {
+        // fashion_mnist
+        USearchIndexCreator fm_creator(64);
+        fm_creator.createIndexes(0);
+        // mnist
+        USearchIndexCreator m_creator(64);
+        m_creator.createIndexes(1);
+        // sift
+        USearchIndexCreator s_creator(64);
+        s_creator.createIndexes(2);
+        // gist
+        USearchIndexCreator g_creator(64);
+        g_creator.createIndexes(3);
+        std::cout << "All indexes created successfully." << std::endl;
+
+        return 0;
+    } catch (std::exception& e) {
+        std::cerr << "Fatal error: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/embedded-c++/usearch/full_coverage.cpp
+++ b/embedded-c++/usearch/full_coverage.cpp
@@ -130,8 +130,8 @@ USearchFullCoverageRunner(int iterations = 100, int threads = 64) : db(nullptr),
             QueryRunner::aggregateBMStats(con, dataset.name + "_search", test_vectors_count, (dataset_cardinality/partitions.size()));
 
             // Output experiment results to CSV
-            // dir name: usearch/results/{experiment}/{dataset_name}_{num_queries}q_{num_iterations}i_{partition_size}p/
-            std::string output_dir = "usearch/results/fullcoverage/" + experiment + dataset.name + "_" + std::to_string(test_vectors_count) + "q_" + std::to_string(max_iterations) + "i_" + std::to_string(dataset_cardinality/partitions.size()) + "p/";
+            // dir name: usearch/results/{experiment}/{dataset_name}_{num_queries}q_{num_iterations}i_{partition_size}r/
+            std::string output_dir = "usearch/results/fullcoverage/" + experiment + dataset.name + "_" + std::to_string(test_vectors_count) + "q_" + std::to_string(max_iterations) + "i_" + std::to_string(dataset_cardinality/partitions.size()) + "r/";
             // Create the directory if it doesn't exist
             std::filesystem::create_directories(output_dir);
             FileOperations::cleanupOutputFiles(output_dir);
@@ -144,6 +144,7 @@ USearchFullCoverageRunner(int iterations = 100, int threads = 64) : db(nullptr),
             // Move lib output files to output dir
             FileOperations::copyFileTo("node_connectivity.csv", output_dir + "node_connectivity.csv");
             FileOperations::copyFileTo("memory_stats.csv", output_dir + "memory_stats.csv");
+            FileOperations::copyFileTo("node_neighbors.csv", output_dir + "node_neighbors.csv");
 
             // Cleanup intermediate files
             FileOperations::cleanupOutputFiles(std::filesystem::current_path());
@@ -172,18 +173,17 @@ int main() {
     int max_iterations = 100;
     int threads = 32;
     
-    // original - no changes to fixed-size ring buffer, tests original USearch implementation w/o changing source code
-    // no_rb_cap - ring buffer cap increased to ceil2(50000) (highest expected add/del batch so all add followed by del replace 100% of deleted nodes). (!!) Requires changing index.hpp reserve ring buffer implementation min val
+    // original_ - tests original USearch implementation w/o changing source code
     experiment = "original_";
 
     try {
-        // fashion_mnist
-        USearchFullCoverageRunner fm_runner(max_iterations, threads);
-        fm_runner.runTest(0);
+        // // fashion_mnist
+        // USearchFullCoverageRunner fm_runner(max_iterations, threads);
+        // fm_runner.runTest(0);
 
-        // mnist
-        USearchFullCoverageRunner m_runner(max_iterations, threads);
-        m_runner.runTest(1);
+        // // mnist
+        // USearchFullCoverageRunner m_runner(max_iterations, threads);
+        // m_runner.runTest(1);
 
         // sift
         USearchFullCoverageRunner s_runner(max_iterations, threads);

--- a/embedded-c++/usearch/full_coverage.cpp
+++ b/embedded-c++/usearch/full_coverage.cpp
@@ -174,16 +174,16 @@ int main() {
     int threads = 32;
     
     // original_ - tests original USearch implementation w/o changing source code
-    experiment = "original_";
+    experiment = "usearch_";
 
     try {
-        // // fashion_mnist
-        // USearchFullCoverageRunner fm_runner(max_iterations, threads);
-        // fm_runner.runTest(0);
+        // fashion_mnist
+        USearchFullCoverageRunner fm_runner(max_iterations, threads);
+        fm_runner.runTest(0);
 
-        // // mnist
-        // USearchFullCoverageRunner m_runner(max_iterations, threads);
-        // m_runner.runTest(1);
+        // mnist
+        USearchFullCoverageRunner m_runner(max_iterations, threads);
+        m_runner.runTest(1);
 
         // sift
         USearchFullCoverageRunner s_runner(max_iterations, threads);

--- a/embedded-c++/usearch/helpers/file_operations.cpp
+++ b/embedded-c++/usearch/helpers/file_operations.cpp
@@ -3,13 +3,15 @@
 void FileOperations::cleanupOutputFiles(std::filesystem::path path = std::filesystem::current_path()) {
     try {
         std::string file_extension = ".csv";
+        std::string file_extension_txt = ".txt";
 
         for (const auto& entry : std::filesystem::directory_iterator(path)) {
             std::string file_path_string = entry.path().string();
 
             // Only remove if file ends with ".csv"
             if (file_path_string.size() >= 4 &&
-                file_path_string.substr(file_path_string.size() - 4) == file_extension) {
+                (file_path_string.substr(file_path_string.size() - 4) == file_extension) || 
+                ((file_path_string.substr(file_path_string.size() - 4) == file_extension_txt && file_path_string.substr(file_path_string.size() - 14) != "CMakeLists.txt"))) {
                 std::filesystem::remove(entry.path());
             }
         }

--- a/embedded-c++/usearch/helpers/index_operations.cpp
+++ b/embedded-c++/usearch/helpers/index_operations.cpp
@@ -298,12 +298,13 @@ size_t IndexOperations::singleRemove(
     size_t removed_count = 0;
 
     auto batch_start = std::chrono::high_resolution_clock::now();
+    size_t total_vectors = sample_vecs->RowCount();
 
     try {
         for (idx_t i = 0; i < sample_vecs->RowCount(); i++) {
             auto id = sample_vecs->GetValue<int>(0, i);
             auto start_time = std::chrono::high_resolution_clock::now();
-            index.remove(id);
+            index.remove(id, total_vectors);
             auto end_time = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration<double>(end_time - start_time).count();
             del_bm_appender.AppendRow(

--- a/embedded-c++/usearch/helpers/index_operations.cpp
+++ b/embedded-c++/usearch/helpers/index_operations.cpp
@@ -689,7 +689,7 @@ TestVectorData IndexOperations::parallelExactSearch(Connection& con, index_dense
  */
 void IndexOperations::parallelRunTestQueries(Connection& con, index_dense_gt<row_t>& index, const std::string& table_name,
     const unique_ptr<MaterializedQueryResult>& test_vectors, Appender& appender, Appender& search_appender, 
-    Appender& early_term_appender, int iteration, int dataset_size, bool get_neighbors) {
+    Appender& early_term_appender, int iteration, int dataset_size) {
     std::cout << "🧪 RUNNING TEST QUERIES 🧪" << std::endl;
 
     try {
@@ -702,19 +702,11 @@ void IndexOperations::parallelRunTestQueries(Connection& con, index_dense_gt<row
         test_vector_indices.reserve(test_vectors->RowCount());
         neighbor_ids_values.reserve(test_vectors->RowCount());
 
-        // For new data scenario we have to get the neighbors for each iteration
-        if (get_neighbors) {
-            TestVectorData data = parallelExactSearch(con, index, test_vectors);
-            test_vecs = data.test_vecs;
-            test_vector_indices = data.test_vector_indices;
-            neighbor_ids_values = data.neighbor_ids_values;
-        } else {
-            for (idx_t i = 0; i < test_vectors->RowCount(); i++) {
-                test_vecs.push_back(ExtractFloatVector(test_vectors->GetValue(1, i)));
-                test_vector_indices.push_back(test_vectors->GetValue(0, i).GetValue<int>());
-                neighbor_ids_values.push_back(test_vectors->GetValue(2, i));
-            }
-        }
+        // Get the neighbors for each iteration though exact search where k = 100
+        TestVectorData data = parallelExactSearch(con, index, test_vectors);
+        test_vecs = data.test_vecs;
+        test_vector_indices = data.test_vector_indices;
+        neighbor_ids_values = data.neighbor_ids_values;
 
         // Thread-safe containers for results
         std::mutex results_mutex;

--- a/embedded-c++/usearch/helpers/index_operations.h
+++ b/embedded-c++/usearch/helpers/index_operations.h
@@ -32,7 +32,7 @@ public:
         
     static void parallelRunTestQueries(Connection& con, index_dense_gt<row_t>& index, const std::string& table_name,
         const unique_ptr<MaterializedQueryResult>& test_vectors, Appender& appender, Appender& search_appender, 
-        Appender& early_term_appender, int iteration, int dataset_size, bool get_neighbors = false);
+        Appender& early_term_appender, int iteration, int dataset_size);
     
     static TestVectorData parallelExactSearch(Connection& con, index_dense_gt<row_t>& index,
         const unique_ptr<MaterializedQueryResult>& test_vectors);

--- a/embedded-c++/usearch/helpers/query_runner.h
+++ b/embedded-c++/usearch/helpers/query_runner.h
@@ -3,6 +3,7 @@
 #include "duckdb.hpp"
 
 #include <iostream>
+#include <fstream>
 
 using namespace duckdb;
 
@@ -12,6 +13,7 @@ public:
     static void aggregateRecallStats(Connection& con, const std::string& table_name);
     static void aggregateBMStats(Connection& con, const std::string& table_name, size_t num_queries, size_t num_del_add);
     static void outputTableAsCSV(Connection& con, const std::string& full_table_name, const std::string& output_file_name);
-    static unique_ptr<MaterializedQueryResult> getSampleVectors(Connection& con, const std::string& table_name, int percentage = 1);
+    static unique_ptr<MaterializedQueryResult> getSampleVectors(Connection& con, const std::string& table_name, int rows = 1);
+    static unique_ptr<MaterializedQueryResult> getSampleNonUnreachableVectors(Connection& con, const std::string& table_name, int rows = 5);
     static std::vector<unique_ptr<MaterializedQueryResult>> partitionDataset(Connection& con, const std::string& table_name, int num_partitions = 100);
 };

--- a/embedded-c++/usearch/new_data.cpp
+++ b/embedded-c++/usearch/new_data.cpp
@@ -86,7 +86,7 @@ USearchNewDataRunner(int iterations = 100, int threads = 64) : db(nullptr), con(
             Appender early_termination_appender(con, "early_terminated_queries");
 
             // Initial query run (multi-threaded)
-            IndexOperations::parallelRunTestQueries(con, index, dataset.name, test_vectors, appender, search_bm_appender, early_termination_appender, 0, dataset_cardinality, true);
+            IndexOperations::parallelRunTestQueries(con, index, dataset.name, test_vectors, appender, search_bm_appender, early_termination_appender, 0, dataset_cardinality);
 
             // Run iterations
             for (int iteration = 1; iteration <= 10; iteration++) {
@@ -110,7 +110,7 @@ USearchNewDataRunner(int iterations = 100, int threads = 64) : db(nullptr), con(
                 // Run test queries (multi-threaded)
                 IndexOperations::parallelRunTestQueries(con, index, dataset.name, test_vectors, appender, 
                                         search_bm_appender, early_termination_appender, 
-                                        iteration, dataset_cardinality, true);
+                                        iteration, dataset_cardinality);
 
                 std::cout << "✅ FINISHED ITERATION " << iteration << " ✅" << std::endl;
             }
@@ -177,16 +177,16 @@ int main() {
     int threads = 32;
     
     // original_ - tests original USearch implementation w/o changing source code
-    experiment = "original_";
+    experiment = "usearch_";
 
     try {
-        // // fashion_mnist
-        // USearchNewDataRunner fm_runner(max_iterations, threads);
-        // fm_runner.runTest(0);
+        // fashion_mnist
+        USearchNewDataRunner fm_runner(max_iterations, threads);
+        fm_runner.runTest(0);
 
-        // // mnist
-        // USearchNewDataRunner m_runner(max_iterations, threads);
-        // m_runner.runTest(1);
+        // mnist
+        USearchNewDataRunner m_runner(max_iterations, threads);
+        m_runner.runTest(1);
 
         // sift
         USearchNewDataRunner s_runner(max_iterations, threads);

--- a/embedded-c++/usearch/new_data.cpp
+++ b/embedded-c++/usearch/new_data.cpp
@@ -131,8 +131,8 @@ USearchNewDataRunner(int iterations = 100, int threads = 64) : db(nullptr), con(
             QueryRunner::aggregateBMStats(con, dataset.name + "_search", test_vectors_count, (dataset_cardinality/partitions.size()));
 
             // Output experiment results to CSV
-            // dir name: usearch/results/{experiment}/{dataset_name}_{num_queries}q_{num_iterations}i_{partition_size}p/
-            std::string output_dir = "usearch/results/newdata/" + experiment + dataset.name + "_" + std::to_string(test_vectors_count) + "q_" + std::to_string(max_iterations) + "i_" + std::to_string(dataset_cardinality/partitions.size()) + "p/";
+            // dir name: usearch/results/{experiment}/{dataset_name}_{num_queries}q_{num_iterations}i_{partition_size}r/
+            std::string output_dir = "usearch/results/newdata/" + experiment + dataset.name + "_" + std::to_string(test_vectors_count) + "q_" + std::to_string(max_iterations) + "i_" + std::to_string(dataset_cardinality/partitions.size()) + "r/";
             // Create the directory if it doesn't exist
             std::filesystem::create_directories(output_dir);
             FileOperations::cleanupOutputFiles(output_dir);
@@ -145,6 +145,7 @@ USearchNewDataRunner(int iterations = 100, int threads = 64) : db(nullptr), con(
             // Move lib output files to output dir
             FileOperations::copyFileTo("node_connectivity.csv", output_dir + "node_connectivity.csv");
             FileOperations::copyFileTo("memory_stats.csv", output_dir + "memory_stats.csv");
+            FileOperations::copyFileTo("node_neighbors.csv", output_dir + "node_neighbors.csv");
 
             // Cleanup intermediate files
             FileOperations::cleanupOutputFiles(std::filesystem::current_path());
@@ -175,18 +176,17 @@ int main() {
     int max_iterations = 10;
     int threads = 32;
     
-    // original - no changes to fixed-size ring buffer, tests original USearch implementation w/o changing source code
-    // no_rb_cap - ring buffer cap increased to ceil2(50000) (highest expected add/del batch so all add followed by del replace 100% of deleted nodes). (!!) Requires changing index.hpp reserve ring buffer implementation min val
+    // original_ - tests original USearch implementation w/o changing source code
     experiment = "original_";
 
     try {
-        // fashion_mnist
-        USearchNewDataRunner fm_runner(max_iterations, threads);
-        fm_runner.runTest(0);
+        // // fashion_mnist
+        // USearchNewDataRunner fm_runner(max_iterations, threads);
+        // fm_runner.runTest(0);
 
-        // mnist
-        USearchNewDataRunner m_runner(max_iterations, threads);
-        m_runner.runTest(1);
+        // // mnist
+        // USearchNewDataRunner m_runner(max_iterations, threads);
+        // m_runner.runTest(1);
 
         // sift
         USearchNewDataRunner s_runner(max_iterations, threads);

--- a/embedded-c++/usearch/random.cpp
+++ b/embedded-c++/usearch/random.cpp
@@ -83,7 +83,6 @@ USearchRandomRunner(int iterations = 200, int threads = 64) : db(nullptr), con(d
             auto perc = 0.01;
             std::ostringstream perc_str;
             perc_str << std::fixed << std::setprecision(2) << perc;
-            std::string perc_formatted = perc_str.str();
             auto sample_size = perc * dataset_cardinality;
 
             // Create appender for results
@@ -138,8 +137,8 @@ USearchRandomRunner(int iterations = 200, int threads = 64) : db(nullptr), con(d
             QueryRunner::aggregateBMStats(con, dataset.name + "_search", test_vectors_count, sample_size);
 
             // Output experiment results to CSV
-            // dir name: usearch/results/{experiment}/{dataset_name}_{num_queries}q_{num_iterations}i_{sample_fraction}s/
-            std::string output_dir = "usearch/results/random/" + experiment + dataset.name + "_" + std::to_string(test_vectors_count) + "q_" + std::to_string(max_iterations) + "i_" + perc_formatted + "s/";
+            // dir name: usearch/results/{experiment}/{dataset_name}_{num_queries}q_{num_iterations}i_{sample_size}r/
+            std::string output_dir = "usearch/results/random/" + experiment + dataset.name + "_" + std::to_string(test_vectors_count) + "q_" + std::to_string(max_iterations) + "i_" + std::to_string(sample_size) + "r/";
             // Create the directory if it doesn't exist
             std::filesystem::create_directories(output_dir);
             FileOperations::cleanupOutputFiles(output_dir);
@@ -152,6 +151,7 @@ USearchRandomRunner(int iterations = 200, int threads = 64) : db(nullptr), con(d
             // Move lib output files to output dir
             FileOperations::copyFileTo("node_connectivity.csv", output_dir + "node_connectivity.csv");
             FileOperations::copyFileTo("memory_stats.csv", output_dir + "memory_stats.csv");
+            FileOperations::copyFileTo("node_neighbors.csv", output_dir + "node_neighbors.csv");
 
             // Cleanup intermediate files
             FileOperations::cleanupOutputFiles(std::filesystem::current_path());
@@ -181,18 +181,17 @@ int main() {
     int max_iterations = 200;
     int threads = 32;
     
-    // original - no changes to fixed-size ring buffer, tests original USearch implementation w/o changing source code
-    // no_rb_cap - ring buffer cap increased to ceil2(50000) (highest expected add/del batch so all add followed by del replace 100% of deleted nodes). (!!) Requires changing index.hpp reserve ring buffer implementation min val
+    // original_ - tests original USearch implementation w/o changing source code
     experiment = "original_";
 
     try {
-        // fashion_mnist
-        USearchRandomRunner fm_runner(max_iterations, threads);
-        fm_runner.runTest(0);
+        // // fashion_mnist
+        // USearchRandomRunner fm_runner(max_iterations, threads);
+        // fm_runner.runTest(0);
 
-        // mnist
-        USearchRandomRunner m_runner(max_iterations, threads);
-        m_runner.runTest(1);
+        // // mnist
+        // USearchRandomRunner m_runner(max_iterations, threads);
+        // m_runner.runTest(1);
 
         // sift
         USearchRandomRunner s_runner(max_iterations, threads);

--- a/embedded-c++/usearch/random.cpp
+++ b/embedded-c++/usearch/random.cpp
@@ -182,16 +182,16 @@ int main() {
     int threads = 32;
     
     // original_ - tests original USearch implementation w/o changing source code
-    experiment = "original_";
+    experiment = "usearch_";
 
     try {
-        // // fashion_mnist
-        // USearchRandomRunner fm_runner(max_iterations, threads);
-        // fm_runner.runTest(0);
+        // fashion_mnist
+        USearchRandomRunner fm_runner(max_iterations, threads);
+        fm_runner.runTest(0);
 
-        // // mnist
-        // USearchRandomRunner m_runner(max_iterations, threads);
-        // m_runner.runTest(1);
+        // mnist
+        USearchRandomRunner m_runner(max_iterations, threads);
+        m_runner.runTest(1);
 
         // sift
         USearchRandomRunner s_runner(max_iterations, threads);

--- a/embedded-c++/usearch/unreachable_points.cpp
+++ b/embedded-c++/usearch/unreachable_points.cpp
@@ -1,0 +1,215 @@
+#include <usearch/index.hpp>
+#include <usearch/index_dense.hpp>
+#include "duckdb.hpp"
+#include "usearch/helpers/index_operations.h"
+#include "usearch/helpers/database_setup.h"
+#include "usearch/helpers/query_runner.h"
+#include "usearch/helpers/file_operations.h"
+
+using namespace duckdb;
+using namespace unum::usearch;
+
+std::string experiment;
+
+// ==================== Main Random Unreachable Points USearch Runner ====================
+class USearchRandomUPRunner {
+private:
+    DuckDB db;
+    Connection con;
+    std::vector<DatasetConfig> datasets;
+    int max_iterations;
+    int threads;
+
+public:
+USearchRandomUPRunner(int iterations = 3000, int threads = 64) : db(nullptr), con(db), max_iterations(iterations) {
+        con.Query("SET THREADS TO " + std::to_string(threads) + ";");
+        datasets = DatabaseSetup::getDatasetConfigs();
+    }
+
+    void runTest(int datasetIdx = 0) {
+        try {
+            // Cleanup intermediate files
+            FileOperations::cleanupOutputFiles(std::filesystem::current_path());
+
+            // Limit to valid dataset indices
+            if (datasetIdx < 0 || datasetIdx >= (int)datasets.size()) {
+                std::cerr << "Invalid dataset index: " << datasetIdx << std::endl;
+                return;
+            }
+
+            const auto& dataset = datasets[datasetIdx];
+
+            std::cout << "📊 TESTING DATASET: " << dataset.name << " 📊" << std::endl;
+
+            // Setup database tables
+            DatabaseSetup::initializeResultsTable(con, dataset.name);
+            DatabaseSetup::initializeBMTable(con, dataset.name + "_del");
+            DatabaseSetup::initializeBMTable(con, dataset.name + "_add");
+            DatabaseSetup::initializeBMTable(con, dataset.name + "_search");
+            DatabaseSetup::intializeEarlyTermTable(con);
+            DatabaseSetup::setupFullDataset(con, dataset);
+
+            // Create the usearch index
+            std::size_t vector_size = dataset.dimensions;
+            auto scalar_kind = scalar_kind_t::f32_k;
+            auto metric_kind = metric_kind_t::l2sq_k;
+
+            metric_punned_t metric(vector_size, metric_kind, scalar_kind);
+            index_dense_config_t config = {};
+
+            // Set M and efConstruction based on dataset
+            config.expansion_add = dataset.ef_construction;
+            config.connectivity = dataset.m;
+
+            auto index = index_dense_gt<row_t>::make(metric, config);
+
+            auto dataset_cardinality = con.Query("SELECT COUNT(*) FROM " + dataset.name + "_train;")->GetValue<int64_t>(0, 0);
+
+            std::size_t executor_threads = std::min(std::thread::hardware_concurrency(),
+                                                static_cast<unsigned int>(dataset_cardinality));
+            executor_default_t executor(executor_threads);
+
+            index.reserve(index_limits_t {NextPowerOfTwo(dataset_cardinality), executor.size()});
+
+            // Load index
+            std::string path = "usearch/indexes/" + dataset.name + "_index.usearch";
+            index.load(path.c_str());
+
+            // Log initial index stats
+            index.log_links();
+
+            // Get test vectors
+            auto test_vectors = con.Query("SELECT * FROM " + dataset.name + "_test;");
+            auto test_vectors_count = test_vectors->RowCount();
+
+            // TODO: hardcoded value
+            auto perc = 0.05;
+            std::ostringstream perc_str;
+            perc_str << std::fixed << std::setprecision(2) << perc;
+            std::string perc_formatted = perc_str.str();
+            auto sample_size = perc * dataset_cardinality;
+
+            // Create appender for results
+            Appender appender(con, dataset.name + "_results");
+            Appender del_bm_appender(con, dataset.name + "_del_bm");
+            Appender add_bm_appender(con, dataset.name + "_add_bm");
+            Appender search_bm_appender(con, dataset.name + "_search_bm");
+            Appender early_termination_appender(con, "early_terminated_queries");
+
+            // Initial query run (multi-threaded)
+            IndexOperations::parallelRunTestQueries(con, index, dataset.name, test_vectors, appender, search_bm_appender, early_termination_appender, 0, dataset_cardinality);
+
+            // Run iterations
+            for (int iteration = 1; iteration <= max_iterations; iteration++) {
+                std::cout << "▶️ ITERATION " << iteration << " ▶️" << std::endl;
+
+                // Get sample vectors to delete and re-add
+                auto sample_vecs = QueryRunner::getSampleNonUnreachableVectors(con, dataset.name, sample_size);
+
+                // Delete sample vectors
+                size_t removed = IndexOperations::singleRemove(index, sample_vecs, dataset.name,
+                                                            iteration, del_bm_appender);
+
+                // Re-add sample vectors (multi-threaded)
+                size_t added = IndexOperations::parallelAdd(index, sample_vecs, dataset.name,
+                                                        iteration, add_bm_appender);
+
+                // Log index stats - also updates unreachable_points.txt for next iteration
+                index.log_links();
+
+                // Run test queries (multi-threaded)
+                IndexOperations::parallelRunTestQueries(con, index, dataset.name, test_vectors, appender,
+                                        search_bm_appender, early_termination_appender,
+                                        iteration, dataset_cardinality);
+
+                std::cout << "✅ FINISHED ITERATION " << iteration << " ✅" << std::endl;
+            }
+
+            appender.Close();
+            early_termination_appender.Close();
+            del_bm_appender.Close();
+            add_bm_appender.Close();
+            search_bm_appender.Close();
+
+            // Calculate recall and aggregate stats
+            QueryRunner::calculateRecall(con, dataset.name);
+            QueryRunner::aggregateRecallStats(con, dataset.name);
+
+            // Aggregate bm stats
+            QueryRunner::aggregateBMStats(con, dataset.name + "_del", test_vectors_count, sample_size);
+            QueryRunner::aggregateBMStats(con, dataset.name + "_add", test_vectors_count, sample_size);
+            QueryRunner::aggregateBMStats(con, dataset.name + "_search", test_vectors_count, sample_size);
+
+            // Output experiment results to CSV
+            // dir name: usearch/results/{experiment}/{dataset_name}_{num_queries}q_{num_iterations}i_{sample_fraction}s/
+            std::string output_dir = "usearch/results/unreachable_points/" + experiment + dataset.name + "_" + std::to_string(test_vectors_count) + "q_" + std::to_string(max_iterations) + "i_" + perc_formatted + "s/";
+            // Create the directory if it doesn't exist
+            std::filesystem::create_directories(output_dir);
+            FileOperations::cleanupOutputFiles(output_dir);
+            QueryRunner::outputTableAsCSV(con, "recall_stats", output_dir + "search_query_stats.csv");
+            QueryRunner::outputTableAsCSV(con, "early_terminated_queries", output_dir + "early_terminated_queries.csv");
+            QueryRunner::outputTableAsCSV(con, dataset.name + "_del_bm_stats", output_dir + "bm_delete.csv");
+            QueryRunner::outputTableAsCSV(con, dataset.name + "_add_bm_stats", output_dir + "bm_add.csv");
+            QueryRunner::outputTableAsCSV(con, dataset.name + "_search_bm_stats", output_dir + "bm_search.csv");
+
+            // Move lib output files to output dir
+            FileOperations::copyFileTo("node_connectivity.csv", output_dir + "node_connectivity.csv");
+            FileOperations::copyFileTo("memory_stats.csv", output_dir + "memory_stats.csv");
+
+            // Cleanup intermediate files
+            FileOperations::cleanupOutputFiles(std::filesystem::current_path());
+
+            // Save the final index
+            std::string s_path = output_dir + "unreachable_points_" + dataset.name + "_index.usearch";
+            index.save(s_path.c_str());
+            std::cout << "Index saved to: " << s_path << std::endl;
+
+
+        } catch (std::exception& e) {
+            std::cerr << "Error running test: " << e.what() << std::endl;
+        }
+    }
+};
+
+// ==================== Main Function ====================
+int main() {
+
+    /**
+     * UNREACHABLEPOINTS:
+     * 3000 iterations. Within each iteration, 5% of vectors that are NOT unreachable in
+     * the index are deleted and then reinserted to track the growth of unreachable
+     * points over iterations. Same experiment as Enhancing HNSW paper. Should prove
+     * that points already in the unreachable points set will not be searched in
+     * future search processes.
+     */
+
+    int max_iterations = 3000;
+    int threads = 32;
+
+    // original - no changes to fixed-size ring buffer, tests original USearch implementation w/o changing source code
+    // no_rb_cap - ring buffer cap increased to ceil2(50000) (highest expected add/del batch so all add followed by del replace 100% of deleted nodes). (!!) Requires changing index.hpp reserve ring buffer implementation min val
+    experiment = "original_";
+
+    try {
+        // fashion_mnist
+        USearchRandomUPRunner fm_runner(max_iterations, threads);
+        fm_runner.runTest(0);
+
+        // mnist
+        USearchRandomUPRunner m_runner(max_iterations, threads);
+        m_runner.runTest(1);
+
+        // sift
+        USearchRandomUPRunner s_runner(max_iterations, threads);
+        s_runner.runTest(2);
+
+        // gist
+        USearchRandomUPRunner g_runner(max_iterations, threads);
+        g_runner.runTest(3);
+
+        return 0;
+    } catch (std::exception& e) {
+        std::cerr << "Fatal error: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/embedded-c++/usearch/unreachable_points.cpp
+++ b/embedded-c++/usearch/unreachable_points.cpp
@@ -86,7 +86,6 @@ USearchRandomUPRunner(int iterations = 3000, int threads = 64) : db(nullptr), co
             auto perc = 0.05;
             std::ostringstream perc_str;
             perc_str << std::fixed << std::setprecision(2) << perc;
-            std::string perc_formatted = perc_str.str();
             auto sample_size = perc * dataset_cardinality;
 
             // Create appender for results
@@ -141,8 +140,8 @@ USearchRandomUPRunner(int iterations = 3000, int threads = 64) : db(nullptr), co
             QueryRunner::aggregateBMStats(con, dataset.name + "_search", test_vectors_count, sample_size);
 
             // Output experiment results to CSV
-            // dir name: usearch/results/{experiment}/{dataset_name}_{num_queries}q_{num_iterations}i_{sample_fraction}s/
-            std::string output_dir = "usearch/results/unreachable_points/" + experiment + dataset.name + "_" + std::to_string(test_vectors_count) + "q_" + std::to_string(max_iterations) + "i_" + perc_formatted + "s/";
+            // dir name: usearch/results/{experiment}/{dataset_name}_{num_queries}q_{num_iterations}i_{sample_fraction}r/
+            std::string output_dir = "usearch/results/unreachable_points/" + experiment + dataset.name + "_" + std::to_string(test_vectors_count) + "q_" + std::to_string(max_iterations) + "i_" + std::to_string(sample_size) + "r/";
             // Create the directory if it doesn't exist
             std::filesystem::create_directories(output_dir);
             FileOperations::cleanupOutputFiles(output_dir);
@@ -186,8 +185,7 @@ int main() {
     int max_iterations = 3000;
     int threads = 32;
 
-    // original - no changes to fixed-size ring buffer, tests original USearch implementation w/o changing source code
-    // no_rb_cap - ring buffer cap increased to ceil2(50000) (highest expected add/del batch so all add followed by del replace 100% of deleted nodes). (!!) Requires changing index.hpp reserve ring buffer implementation min val
+    // original_ - tests original USearch implementation w/o changing source code
     experiment = "original_";
 
     try {

--- a/embedded-c++/usearch/unreachable_points.cpp
+++ b/embedded-c++/usearch/unreachable_points.cpp
@@ -186,7 +186,7 @@ int main() {
     int threads = 32;
 
     // original_ - tests original USearch implementation w/o changing source code
-    experiment = "original_";
+    experiment = "usearch_";
 
     try {
         // fashion_mnist

--- a/python/scripts/plots/benchmark_plots.py
+++ b/python/scripts/plots/benchmark_plots.py
@@ -147,10 +147,10 @@ def generate_benchmark_plots(experiment_paths: Dict[str, List[str]]):
             # Extract dataset name from the folder path
             dataset_name = os.path.basename(dataset_path)
             # Handle special case for fashion-mnist
-            if dataset_name.startswith("fashion_mnist"):
+            if "fashion_mnist" in dataset_name:
                 dataset_name = "fashion-mnist"
             else:
-                dataset_name = dataset_name.split('_')[0]
+                dataset_name = dataset_name.split('_')[1]
 
             # Load benchmark data
             benchmark_dfs = {}

--- a/python/scripts/plots/memory_connectivity_plots.py
+++ b/python/scripts/plots/memory_connectivity_plots.py
@@ -120,7 +120,7 @@ def plot_node_connectivity(df: pd.DataFrame,
             fig, ax = plt.subplots(figsize=(10, 6))
             ax.plot(iterations, df[metric], color=color, linewidth=2)
 
-            ax.set_title(f'{metric.replace("_", " ").title()} Over Iterations - {filename.split("_")[0].title()} ({dataset_name})')
+            ax.set_title(f'{metric.replace("_", " ").title()} Over Iterations - {filename.split("_")[1].title()} ({dataset_name})')
             ax.set_xlabel('Iteration')
             ax.set_ylabel('Count')
             ax.grid(True, alpha=0.3)
@@ -359,7 +359,7 @@ def generate_memory_connectivity_plots(experiment_paths: Dict[str, List[str]]):
             os.makedirs(save_dir, exist_ok=True)
 
             dataset_name = os.path.basename(dataset_path)
-            dataset_name = "fashion-mnist" if dataset_name.startswith("fashion_mnist") else dataset_name.split('_')[0]
+            dataset_name = "fashion-mnist" if "fashion_mnist" in dataset_name else dataset_name.split('_')[1]
 
             # Memory stats plots
             memory_stats_path = os.path.join(dataset_path, 'memory_stats.csv')
@@ -401,7 +401,7 @@ def generate_memory_connectivity_plots(experiment_paths: Dict[str, List[str]]):
             if os.path.exists(connectivity_path):
                 connectivity_df = load_csv_data(connectivity_path)
                 dataset_name = os.path.basename(dataset_path)
-                dataset_name = "fashion-mnist" if dataset_name.startswith("fashion_mnist") else dataset_name.split('_')[0]
+                dataset_name = "fashion-mnist" if "fashion_mnist" in dataset_name else dataset_name.split('_')[1]
 
                 # Original connectivity plots
                 plot_node_connectivity(

--- a/python/scripts/plots/memory_connectivity_plots.py
+++ b/python/scripts/plots/memory_connectivity_plots.py
@@ -449,7 +449,7 @@ def generate_memory_connectivity_plots(experiment_paths: Dict[str, List[str]]):
                 # Plot scatter and recall plots if search stats exist
                 if os.path.exists(search_stats_path):
                     search_df = load_csv_data(search_stats_path)
-                    dataset_name = search_df['dataset'].iloc[0]
+                    # dataset_name = search_df['dataset'].iloc[0]
                     if len(search_df) == len(connectivity_df):
                         # New scatter plot with mean recall colormap
                         plot_connectivity_scatter(

--- a/python/scripts/plots/search_analysis_plots.py
+++ b/python/scripts/plots/search_analysis_plots.py
@@ -192,7 +192,7 @@ def plot_visited_vs_computed(df: pd.DataFrame,
 
     ax.set_xlabel('Mean Number of Visited Members')
     ax.set_ylabel('Mean Number of Computed Distances')
-    ax.set_title(f'Visited Members vs Computed Distances - {filename.split("_")[0].title()} ({dataset_name})')
+    ax.set_title(f'Visited Members vs Computed Distances - {filename.split("_")[1].title()} ({dataset_name})')
     ax.grid(True)
 
     # Set axis limits without forcing x-axis to start at 0

--- a/python/scripts/plots/search_analysis_plots.py
+++ b/python/scripts/plots/search_analysis_plots.py
@@ -10,6 +10,7 @@ from scripts.plots.plot_utils import (load_csv_data, calculate_error_bounds,
                         plot_with_error_bounds, setup_plot_style, save_plot, set_axis_limits)
 
 def plot_early_termination_analysis(
+    dataset_name: str,
     df: pd.DataFrame,
     save_dir: str,
     filename: str
@@ -24,7 +25,7 @@ def plot_early_termination_analysis(
 
 
     # Extract dataset name from the filename
-    dataset_name = df['dataset'].iloc[0]
+    # dataset_name = df['dataset'].iloc[0]
 
     # Check if required columns exist
     required_cols = ['iteration']
@@ -168,14 +169,15 @@ def plot_early_termination_analysis(
         plt.tight_layout()
         save_plot(fig, save_dir, f"{filename}_relationships")
 
-def plot_visited_vs_computed(df: pd.DataFrame,
+def plot_visited_vs_computed(dataset_name: str,
+                      df: pd.DataFrame,
                       save_dir: str,
                       filename: str):
     """Plot the relationship between visited members and computed distances."""
     setup_plot_style()
 
     # Extract dataset name from the title
-    dataset_name = df['dataset'].iloc[0]
+    # dataset_name = df['dataset'].iloc[0]
 
     fig, ax = plt.subplots(figsize=(10, 6))
 
@@ -270,12 +272,20 @@ def generate_search_analysis_plots(experiment_paths: Dict[str, List[str]]):
     for scenario, paths in experiment_paths.items():
         for dataset_path in paths:
             save_dir = os.path.join(dataset_path, 'images')
+            # os.makedirs(save_dir, exist_ok=True)
+
+            dataset_name = os.path.basename(dataset_path)
+            dataset_name = "fashion-mnist" if "fashion_mnist" in dataset_name else dataset_name.split('_')[1]
 
             # Search query stats plots (aggregated data)
             search_stats_path = os.path.join(dataset_path, 'search_query_stats.csv')
             if os.path.exists(search_stats_path):
                 search_df = load_csv_data(search_stats_path)
-                dataset_name = search_df['dataset'].iloc[0]
+                
+                # Only run if search_df is not empty
+                if search_df.empty:
+                    print(f"Warning: No data available for {search_stats_path}")
+                    continue
 
                 # Generate individual metric plots
                 for metric in search_metrics:
@@ -289,6 +299,7 @@ def generate_search_analysis_plots(experiment_paths: Dict[str, List[str]]):
                     )
 
                 plot_visited_vs_computed(
+                    dataset_name,
                     search_df,
                     save_dir,
                     f'{scenario}_search_efficiency'
@@ -298,7 +309,12 @@ def generate_search_analysis_plots(experiment_paths: Dict[str, List[str]]):
             early_termination_path = os.path.join(dataset_path, 'early_terminated_queries.csv')
             if os.path.exists(early_termination_path):
                 early_termination_df = load_csv_data(early_termination_path)
+                # Only run if early_termination_df is not empty
+                if early_termination_df.empty:
+                    print(f"Warning: No data available for {early_termination_path}")
+                    continue
                 plot_early_termination_analysis(
+                    dataset_name,
                     early_termination_df,
                     save_dir,
                     f'{scenario}_early_termination'

--- a/src/include/usearch/index_dense.hpp
+++ b/src/include/usearch/index_dense.hpp
@@ -1226,7 +1226,7 @@ class index_dense_gt {
      *          If the key was not found in the index, `result.completed` will be `false`.
      *          If an error occurred during the removal operation, `result.error` will contain an error message.
      */
-    labeling_result_t remove(vector_key_t key) {
+    labeling_result_t remove(vector_key_t key, size_t batch_size = 1) {
         labeling_result_t result;
 
         unique_lock_t lookup_lock(slot_lookup_mutex_);
@@ -1237,7 +1237,7 @@ class index_dense_gt {
         // Grow the removed entries ring, if needed
         std::size_t matching_count = std::distance(matching_slots.first, matching_slots.second);
         std::unique_lock<std::mutex> free_lock(free_keys_mutex_);
-        if (!free_keys_.reserve(free_keys_.size() + matching_count))
+        if (!free_keys_.reserve(free_keys_.size() + batch_size))
             return result.failed("Can't allocate memory for a free-list");
     
         // A removed entry would be:

--- a/src/include/usearch/index_dense.hpp
+++ b/src/include/usearch/index_dense.hpp
@@ -1221,6 +1221,7 @@ class index_dense_gt {
     /**
      *  @brief Removes an entry with the specified key from the index.
      *  @param[in] key The key of the entry to remove.
+     *  @param[in] batch_size (!ADDED PARAMETER) Expected batch size of experiment deletions.
      *  @return The ::labeling_result_t indicating the result of the removal operation.
      *          If the removal was successful, `result.completed` will be `true`.
      *          If the key was not found in the index, `result.completed` will be `false`.

--- a/src/include/usearch/index_plugins.hpp
+++ b/src/include/usearch/index_plugins.hpp
@@ -29,7 +29,11 @@
 #if defined(__AVX512F__)
 #define USEARCH_USE_FP16LIB 0
 #elif defined(USEARCH_DEFINED_ARM)
-#include <arm_fp16.h> // `__fp16`
+#if __has_include(<arm_fp16.h>)
+#include <arm_fp16.h> // `__fp16` 
+#elif __has_include(<arm_neon.h>)
+#include <arm_neon.h> // May provide `__fp16` on some ARM systems
+#endif
 #define USEARCH_USE_FP16LIB 0
 #else
 #define USEARCH_USE_FP16LIB 1


### PR DESCRIPTION
- Run experiments using Ofast flag
- Update makefile to only build once
- Add program that generates half- and whole indexes for each dataset
- Update all experiments to use same dataset index
- All experiments save final index to results directory
- Add experiment prefix for different experiment types
- Add unreachable points experiment
- Increase ring buffer size
- Add lock contention fix